### PR TITLE
Fixing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,7 @@ In the root folder, there are three subfolders that each contain code to build a
 
 3. Setup environment variable file
 - Make a copy of the file named `.env.example` and save it as `.env`.
-- Modify the new `.env` and enter the information for the `MYSQL` variables. These can be any values you would like as they are applied to the MariaDB instance. These variables are copied to all of the container images. For the `MYSQL_HOST` variable, there are two options:
-
-   * If you're just running the containers as-is, you will set this to `mariadb`.
-   * If you're developing locally and still want to run the database as a container, use `localhost`.
+- Modify the new `.env` and enter the information for the `MYSQL` variables. These can be any values you would like as they are applied to the MariaDB instance. These variables are copied to all of the container images. For the `MYSQL_HOST` variable, you will input `mariadb`. This matches the name of the container for the Maria database defined in `docker-compose-base.yml`.
 
 4. If you are planning to run the `serial` version, you will also need to modify `docker-compose-serial.yml` with the correct USB mapping:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In the root folder, there are three subfolders that each contain code to build a
 
 3. Setup environment variable file
 - Make a copy of the file named `.env.example` and save it as `.env`.
-- Modify the new `.env` and enter the information for the `MYSQL` variables. These can be any values you would like as they are applied to the MariaDB instance. These variables are copied to all of the container images. For the `MYSQL_HOST` variable, you will input `mariadb`. This matches the name of the container for the Maria database defined in `docker-compose-base.yml`.
+- Modify the new `.env` and enter the information for the `MYSQL` variables. These can be any values you would like as they are applied to the MariaDB instance. These variables are copied to all of the container images. For the two `PASSWORD` fields, make sure these values are at least 6 characters in length. For the `MYSQL_HOST` variable, you will input `mariadb`. This matches the name of the container for the Maria database defined in `docker-compose-base.yml`.
 
 4. If you are planning to run the `serial` version, you will also need to modify `docker-compose-serial.yml` with the correct USB mapping:
 

--- a/dms-lite/Dockerfile
+++ b/dms-lite/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:lts-slim
 
+WORKDIR /app
+
 COPY . .
 
 # Installs the DMS Lite packages

--- a/dms-lite/routes/db.js
+++ b/dms-lite/routes/db.js
@@ -21,7 +21,7 @@ async function testDbConnection() {
 		const createTable = await conn.query("CREATE TABLE IF NOT EXISTS clusterData (timestamp DATETIME, duck_id TEXT, topic TEXT, message_id TEXT, payload TEXT, path TEXT, hops INT, duck_type INT)");
 		const createCommandsTable = await conn.query("CREATE TABLE IF NOT EXISTS clusterCommands (timestamp TEXT, topic TEXT, payload TEXT)");
 		console.log("Checked if table exists");
-		const query = await conn.query("INSERT INTO clusterData(timestamp, duck_Id, topic, message_id, payload, path, hops, duck_type) values ('2021-11-14 00:00:00', 'asdf', 'asdf', 'asdf', 'asdf', 'asdf', 1, 1);");
+		// const query = await conn.query("INSERT INTO clusterData(timestamp, duck_Id, topic, message_id, payload, path, hops, duck_type) values ('2021-11-14 00:00:00', 'asdf', 'asdf', 'asdf', 'asdf', 'asdf', 1, 1);");
 	} catch (err) {
 		throw err;
 	} finally {

--- a/serial-sql-writer/Dockerfile
+++ b/serial-sql-writer/Dockerfile
@@ -2,11 +2,13 @@ FROM python:3.10-slim-bullseye
 
 RUN apt update && apt upgrade -y && apt install -y gcc libmariadb-dev libmariadb3
 
+WORKDIR /app
+
 # Copies files from the host into the container
 COPY serial_sqlwriter.py /
 
 # Installs serial and mariadb libraries for python
-RUN pip3 install pyserial mariadb==1.0.3
+RUN pip3 install pyserial mariadb==1.0.11
 
 # Tells Docker to run the python code and where it is located
 ENTRYPOINT [ "python3", "serial_sqlwriter.py" ]

--- a/wifi-sql-writer/Dockerfile
+++ b/wifi-sql-writer/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.10-slim-bullseye
 
 RUN apt update && apt upgrade -y && apt install -y gcc libmariadb-dev libmariadb3
 
+WORKDIR /app
+
 # Copies files from the host into the container
 COPY wifi_sqlwriter.py /
 


### PR DESCRIPTION
In the NodeJS Dockerfile, the lts-slim update must not allow files to be copied into the root directory, so I added a WORKDIR definition. 

I also updated the python sql-writer Dockerfiles to be in sync with each other since they are based on the same container image